### PR TITLE
HDEV-55: Add todo list tools for session-based task management

### DIFF
--- a/docs/todo_tool_enhancements.md
+++ b/docs/todo_tool_enhancements.md
@@ -1,0 +1,123 @@
+# Todo Tools Enhancements
+
+This document describes the enhanced todo tools implementation in the Heare developer framework.
+
+## Overview
+
+The todo tools have been redesigned to provide a more intuitive and flexible interface for todo management. The enhancements include:
+
+1. **Denormalized Single-Todo Operations**: Instead of passing complex structured data, the tools now handle one todo at a time with simple parameters.
+2. **Machine-Readable Metadata**: The `todo_read` tool now includes a structured metadata section to communicate IDs and properties.
+3. **Specialized Tool Functions**: The implementation now provides dedicated tools for specific operations.
+4. **Clear Feedback Responses**: Each tool provides explicit feedback about the changes made.
+5. **Backward Compatibility**: The original `todo_write` tool is maintained for compatibility.
+
+## New Tools
+
+### `todo_read`
+
+Reads and displays the current todo list with metadata.
+
+```python
+todo_read()
+```
+
+### `todo_add`
+
+Adds a new todo item.
+
+```python
+todo_add(content="Implement feature X", priority="high")
+```
+
+### `todo_update`
+
+Updates an existing todo by ID.
+
+```python
+todo_update(todo_id="abc123", content="Updated description", priority="medium", status="in_progress")
+```
+
+### `todo_complete`
+
+Marks a todo as completed.
+
+```python
+todo_complete(todo_id="abc123")
+```
+
+### `todo_delete`
+
+Deletes a todo.
+
+```python
+todo_delete(todo_id="abc123")
+```
+
+## Metadata Format
+
+The `todo_read` tool now includes a machine-readable metadata section in its output, formatted as JSON:
+
+```
+# Todo List
+[ ] Task 1 (medium)
+[→] Task 2 (high)
+[✓] Task 3 (low)
+
+## METADATA
+```json
+{
+  "todos": [
+    {
+      "id": "unique-id-1",
+      "content": "Task 1",
+      "status": "pending",
+      "priority": "medium"
+    },
+    {
+      "id": "unique-id-2",
+      "content": "Task 2",
+      "status": "in_progress",
+      "priority": "high"
+    },
+    {
+      "id": "unique-id-3",
+      "content": "Task 3",
+      "status": "completed",
+      "priority": "low"
+    }
+  ]
+}
+```
+```
+
+This metadata section allows AI assistants to easily extract the IDs needed for operations on specific todos, while keeping the human-readable output clean and focused on the content.
+
+## Use Cases
+
+### Adding a New Todo
+
+```python
+todo_add(content="Implement error handling", priority="high")
+```
+
+### Updating a Todo's Status
+
+```python
+# First, read todos to get the ID
+todos = todo_read()
+# Extract ID from metadata
+todo_update(todo_id="the-extracted-id", status="in_progress")
+```
+
+### Completing Multiple Todos in One Operation
+
+```python
+# Extract IDs from todo_read metadata
+todo_complete(todo_id="id1")
+todo_complete(todo_id="id2")
+```
+
+## Backward Compatibility
+
+The original `todo_write` tool is still available and functions as before, maintaining backward compatibility.

--- a/heare/developer/tools/__init__.py
+++ b/heare/developer/tools/__init__.py
@@ -25,6 +25,10 @@ from .memory import (
     critique_memory,
     delete_memory_entry,
 )
+from .todos import (
+    todo_read,
+    todo_write,
+)
 from .github import GITHUB_TOOLS
 from .github_comments import (
     GITHUB_COMMENT_TOOLS,
@@ -58,6 +62,8 @@ ALL_TOOLS = (
         write_memory_entry,
         critique_memory,
         delete_memory_entry,
+        todo_read,
+        todo_write,
     ]
     + GITHUB_TOOLS
     + GITHUB_COMMENT_TOOLS

--- a/heare/developer/tools/todos.py
+++ b/heare/developer/tools/todos.py
@@ -1,0 +1,291 @@
+"""
+Tools for managing session-based todo lists.
+
+This module provides tools to read and write todos for the current session.
+Todos are stored in JSON files in the ~/.local/share/heare/todos directory,
+with each session having its own todo file named by session ID.
+"""
+
+import json
+from enum import Enum
+from pathlib import Path
+from typing import List, Dict, Any
+from dataclasses import dataclass
+from uuid import uuid4
+
+from heare.developer.context import AgentContext
+from heare.developer.tools.framework import tool
+from heare.developer.utils import get_data_dir, ensure_dir_exists, CustomJSONEncoder
+
+
+class TodoStatus(str, Enum):
+    """Status of a todo item."""
+
+    PENDING = "pending"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+
+
+class TodoPriority(str, Enum):
+    """Priority of a todo item."""
+
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+@dataclass
+class TodoItem:
+    """A todo item."""
+
+    id: str
+    content: str
+    status: TodoStatus
+    priority: TodoPriority
+
+    @classmethod
+    def create(cls, content: str, priority: TodoPriority = TodoPriority.MEDIUM):
+        """Create a new todo item with a unique ID."""
+        return cls(
+            id=str(uuid4()),
+            content=content,
+            status=TodoStatus.PENDING,
+            priority=priority,
+        )
+
+
+def get_todos_dir() -> Path:
+    """Get the directory for storing todos."""
+    todos_dir = get_data_dir() / "todos"
+    ensure_dir_exists(todos_dir)
+    return todos_dir
+
+
+def get_todo_file(session_id: str) -> Path:
+    """Get the path to a todo file for a session."""
+    return get_todos_dir() / f"{session_id}.json"
+
+
+def load_todos(session_id: str) -> List[TodoItem]:
+    """Load todos from a file."""
+    todo_file = get_todo_file(session_id)
+    if not todo_file.exists():
+        return []
+
+    try:
+        with open(todo_file, "r") as f:
+            todos_data = json.load(f)
+
+        return [
+            TodoItem(
+                id=item["id"],
+                content=item["content"],
+                status=TodoStatus(item["status"]),
+                priority=TodoPriority(item["priority"]),
+            )
+            for item in todos_data
+        ]
+    except (json.JSONDecodeError, KeyError, ValueError) as e:
+        # Log the error but return an empty list to avoid disrupting the user
+        print(f"Error loading todos: {e}")
+        return []
+
+
+def save_todos(session_id: str, todos: List[TodoItem]) -> None:
+    """Save todos to a file."""
+    todo_file = get_todo_file(session_id)
+
+    todos_data = [
+        {
+            "id": todo.id,
+            "content": todo.content,
+            "status": todo.status,
+            "priority": todo.priority,
+        }
+        for todo in todos
+    ]
+
+    with open(todo_file, "w") as f:
+        json.dump(todos_data, f, cls=CustomJSONEncoder, indent=2)
+
+
+def sort_todos(todos: List[TodoItem]) -> List[TodoItem]:
+    """Sort todos by status (in_progress first) then priority."""
+    # Define the order of statuses for sorting
+    status_order = {
+        TodoStatus.IN_PROGRESS: 0,
+        TodoStatus.PENDING: 1,
+        TodoStatus.COMPLETED: 2,
+    }
+
+    # Define the order of priorities for sorting
+    priority_order = {TodoPriority.HIGH: 0, TodoPriority.MEDIUM: 1, TodoPriority.LOW: 2}
+
+    return sorted(
+        todos,
+        key=lambda todo: (status_order[todo.status], priority_order[todo.priority]),
+    )
+
+
+def format_todo_list(todos: List[TodoItem]) -> str:
+    """Format a list of todos for display."""
+    if not todos:
+        return "No todos in the current session."
+
+    sorted_todos = sort_todos(todos)
+
+    # Format with status indicators and priorities
+    lines = ["# Todo List", ""]
+
+    for todo in sorted_todos:
+        status_indicator = {
+            TodoStatus.PENDING: "[ ]",
+            TodoStatus.IN_PROGRESS: "[→]",
+            TodoStatus.COMPLETED: "[✓]",
+        }[todo.status]
+
+        priority_indicator = {
+            TodoPriority.HIGH: "(high)",
+            TodoPriority.MEDIUM: "(medium)",
+            TodoPriority.LOW: "(low)",
+        }[todo.priority]
+
+        lines.append(f"{status_indicator} {todo.content} {priority_indicator}")
+
+    return "\n".join(lines)
+
+
+def format_todo_diff(old_todos: List[TodoItem], new_todos: List[TodoItem]) -> str:
+    """Format the difference between two todo lists."""
+    # Create dictionaries for easier comparison
+    old_dict = {todo.id: todo for todo in old_todos}
+    new_dict = {todo.id: todo for todo in new_todos}
+
+    added = [todo for todo in new_todos if todo.id not in old_dict]
+    removed = [todo for todo in old_todos if todo.id not in new_dict]
+    changed = [
+        (old_dict[todo_id], new_dict[todo_id])
+        for todo_id in set(old_dict) & set(new_dict)
+        if old_dict[todo_id].status != new_dict[todo_id].status
+        or old_dict[todo_id].priority != new_dict[todo_id].priority
+        or old_dict[todo_id].content != new_dict[todo_id].content
+    ]
+
+    if not (added or removed or changed):
+        return "No changes to the todo list."
+
+    lines = ["# Todo List Changes", ""]
+
+    if added:
+        lines.append("## Added")
+        for todo in added:
+            lines.append(f"+ {todo.content} ({todo.priority})")
+        lines.append("")
+
+    if removed:
+        lines.append("## Removed")
+        for todo in removed:
+            lines.append(f"- {todo.content}")
+        lines.append("")
+
+    if changed:
+        lines.append("## Changed")
+        for old, new in changed:
+            if old.content != new.content:
+                lines.append(f"* Changed: '{old.content}' → '{new.content}'")
+            if old.status != new.status:
+                lines.append(
+                    f"* Status: '{old.status}' → '{new.status}' for '{new.content}'"
+                )
+            if old.priority != new.priority:
+                lines.append(
+                    f"* Priority: '{old.priority}' → '{new.priority}' for '{new.content}'"
+                )
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def validate_todos(todos_data: List[Dict[str, Any]]) -> List[TodoItem]:
+    """Validate and convert input data to TodoItem objects."""
+    valid_todos = []
+
+    for item in todos_data:
+        try:
+            # Ensure required fields exist
+            if not all(key in item for key in ["content"]):
+                raise ValueError(f"Missing required fields in todo item: {item}")
+
+            # Use existing ID or create new one
+            todo_id = item.get("id", str(uuid4()))
+
+            # Parse status
+            status_str = item.get("status", "pending").lower()
+            if status_str not in [s.value for s in TodoStatus]:
+                raise ValueError(f"Invalid status: {status_str}")
+            status = TodoStatus(status_str)
+
+            # Parse priority
+            priority_str = item.get("priority", "medium").lower()
+            if priority_str not in [p.value for p in TodoPriority]:
+                raise ValueError(f"Invalid priority: {priority_str}")
+            priority = TodoPriority(priority_str)
+
+            # Create TodoItem
+            valid_todos.append(
+                TodoItem(
+                    id=todo_id,
+                    content=item["content"],
+                    status=status,
+                    priority=priority,
+                )
+            )
+        except (ValueError, KeyError) as e:
+            # Log the error but continue processing other items
+            print(f"Error validating todo item: {e}")
+
+    return valid_todos
+
+
+@tool
+def todo_read(context: AgentContext) -> str:
+    """
+    Read the current todo list for the session.
+
+    Returns a formatted list of todos for the current session.
+    """
+    todos = load_todos(context.session_id)
+    return format_todo_list(todos)
+
+
+@tool
+def todo_write(context: AgentContext, todos: List[Dict[str, Any]]) -> str:
+    """
+    Create or update todos in the current session.
+
+    Args:
+        todos: A list of todo items. Each item must have a "content" field and may also have
+              "status" (pending, in_progress, completed), "priority" (high, medium, low),
+              and "id" (to update an existing todo).
+
+    Returns a summary of changes made to the todo list.
+    """
+    # Load existing todos
+    old_todos = load_todos(context.session_id)
+
+    # Validate and convert input
+    new_todos = validate_todos(todos)
+
+    # Preserve existing todos not in the update
+    {todo.id for todo in old_todos}
+    update_ids = {todo.id for todo in new_todos}
+
+    # Add preserved todos (those not in the update)
+    preserved_todos = [todo for todo in old_todos if todo.id not in update_ids]
+    final_todos = preserved_todos + new_todos
+
+    # Save the updated list
+    save_todos(context.session_id, final_todos)
+
+    # Return a diff showing what changed
+    return format_todo_diff(old_todos, final_todos)

--- a/heare/developer/tools/todos.py
+++ b/heare/developer/tools/todos.py
@@ -445,6 +445,13 @@ def todo_write(context: AgentContext, todos: List[Dict[str, Any]]) -> str:
 
     Returns a summary of changes made to the todo list.
     """
+    # assume that we're potentially getting garbage data from the model (json as a string)
+    if isinstance(todos, str):
+        try:
+            todos = json.loads(todos)
+        except json.JSONDecodeError:
+            return "Tool invocation not well formed. 😩"
+
     # Load existing todos
     old_todos = load_todos(context.session_id)
 

--- a/heare/developer/tools/todos.py
+++ b/heare/developer/tools/todos.py
@@ -454,6 +454,7 @@ def todo_write(context: AgentContext, todos: List[Dict[str, Any]]) -> str:
         try:
             # Ensure required fields exist
             if "content" not in item:
+                print("Error validating todo item: Missing required field 'content'")
                 continue
 
             # Use existing ID or create new one
@@ -462,12 +463,14 @@ def todo_write(context: AgentContext, todos: List[Dict[str, Any]]) -> str:
             # Parse status
             status_str = item.get("status", "pending").lower()
             if status_str not in [s.value for s in TodoStatus]:
+                print(f"Error validating todo item: Invalid status '{status_str}'")
                 continue
             status = TodoStatus(status_str)
 
             # Parse priority
             priority_str = item.get("priority", "medium").lower()
             if priority_str not in [p.value for p in TodoPriority]:
+                print(f"Error validating todo item: Invalid priority '{priority_str}'")
                 continue
             priority = TodoPriority(priority_str)
 

--- a/tests/test_todo_tools.py
+++ b/tests/test_todo_tools.py
@@ -1,0 +1,255 @@
+import json
+import uuid
+from unittest import mock
+
+import pytest
+
+from heare.developer.context import AgentContext
+from heare.developer.tools.todos import (
+    todo_read,
+    todo_write,
+    TodoItem,
+    TodoStatus,
+    TodoPriority,
+)
+
+
+@pytest.fixture
+def mock_session_id():
+    return str(uuid.uuid4())
+
+
+@pytest.fixture
+def mock_context(mock_session_id):
+    context = mock.MagicMock(spec=AgentContext)
+    context.session_id = mock_session_id
+    return context
+
+
+@pytest.fixture
+def mock_todo_file(tmp_path, mock_session_id):
+    # Create a temporary directory for todos
+    todos_dir = tmp_path / "todos"
+    todos_dir.mkdir()
+
+    # Create a mock todo file
+    todo_file = todos_dir / f"{mock_session_id}.json"
+
+    # Mock the get_todos_dir function to return our temp directory
+    with mock.patch(
+        "heare.developer.tools.todos.get_todos_dir", return_value=todos_dir
+    ):
+        yield todo_file
+
+
+def test_todo_read_empty(mock_context, mock_todo_file):
+    """Test reading an empty todo list."""
+    # Ensure the file doesn't exist yet
+    assert not mock_todo_file.exists()
+
+    # Call todo_read
+    result = todo_read(mock_context)
+
+    # Check the result
+    assert "No todos in the current session." in result
+
+
+def test_todo_write_and_read(mock_context, mock_todo_file):
+    """Test writing and then reading todos."""
+    # Create some todos
+    todos_data = [
+        {"content": "Task 1", "priority": "high"},
+        {"content": "Task 2", "status": "in_progress"},
+        {"content": "Task 3", "priority": "low", "status": "completed"},
+    ]
+
+    # Write the todos
+    write_result = todo_write(mock_context, todos_data)
+
+    # Check that the file was created
+    assert mock_todo_file.exists()
+
+    # Verify the write result contains expected changes
+    assert "Added" in write_result
+    assert "Task 1" in write_result
+    assert "Task 2" in write_result
+    assert "Task 3" in write_result
+
+    # Read the todos
+    read_result = todo_read(mock_context)
+
+    # Check the read result contains our todos, properly sorted
+    assert "Task 2" in read_result  # in_progress should be first
+    assert "Task 1" in read_result  # high priority should be second
+    assert "Task 3" in read_result  # completed should be last
+
+    # Check the status indicators
+    assert "[→]" in read_result  # for in_progress
+    assert "[ ]" in read_result  # for pending
+    assert "[✓]" in read_result  # for completed
+
+
+def test_todo_update(mock_context, mock_todo_file):
+    """Test updating existing todos."""
+    # First, create some initial todos
+    initial_todos = [
+        {"content": "Task 1", "priority": "medium"},
+        {"content": "Task 2", "priority": "high"},
+    ]
+
+    # Write the initial todos
+    todo_write(mock_context, initial_todos)
+
+    # Read todos to get their IDs
+    with open(mock_todo_file, "r") as f:
+        saved_todos = json.load(f)
+
+    # Update one todo and add a new one
+    updated_todos = [
+        {
+            "id": saved_todos[0]["id"],
+            "content": "Task 1 Updated",
+            "status": "in_progress",
+        },
+        {"content": "Task 3", "priority": "low"},
+    ]
+
+    # Write the updates
+    update_result = todo_write(mock_context, updated_todos)
+
+    # Check the update result
+    assert "Changed" in update_result
+    assert "Task 1" in update_result
+    assert "Task 1 Updated" in update_result
+    assert "Added" in update_result
+    assert "Task 3" in update_result
+
+    # Read the updated todos
+    read_result = todo_read(mock_context)
+
+    # Check that all expected todos are present
+    assert "Task 1 Updated" in read_result
+    assert "Task 2" in read_result  # This one was preserved
+    assert "Task 3" in read_result
+
+    # The updated task should be in_progress and appear first
+    first_line_with_task = next(
+        line for line in read_result.split("\n") if "Task" in line
+    )
+    assert "Task 1 Updated" in first_line_with_task
+    assert "[→]" in first_line_with_task
+
+
+def test_todo_validation(mock_context, mock_todo_file):
+    """Test validation of todo input."""
+    # Test with invalid status and priority
+    invalid_todos = [
+        {"content": "Valid Task"},
+        {"content": "Invalid Status", "status": "not_a_status"},
+        {"content": "Invalid Priority", "priority": "not_a_priority"},
+        {"status": "pending"},  # Missing content
+    ]
+
+    # Write should still work but log errors and skip invalid todos
+    with mock.patch("builtins.print") as mock_print:
+        todo_write(mock_context, invalid_todos)
+
+    # Check that error messages were logged
+    mock_print.assert_called()
+
+    # Read the todos
+    read_result = todo_read(mock_context)
+
+    # Only the valid todo should be present
+    assert "Valid Task" in read_result
+    assert "Invalid Status" not in read_result
+    assert "Invalid Priority" not in read_result
+
+    # Load the saved file directly to check
+    with open(mock_todo_file, "r") as f:
+        saved_todos = json.load(f)
+
+    # There should be only one valid todo
+    assert len(saved_todos) == 1
+    assert saved_todos[0]["content"] == "Valid Task"
+
+
+def test_sort_todos():
+    """Test the sorting of todo items."""
+    from heare.developer.tools.todos import sort_todos
+
+    # Create todos with different statuses and priorities
+    todos = [
+        TodoItem(
+            id="1",
+            content="Low Priority",
+            status=TodoStatus.PENDING,
+            priority=TodoPriority.LOW,
+        ),
+        TodoItem(
+            id="2",
+            content="Completed High",
+            status=TodoStatus.COMPLETED,
+            priority=TodoPriority.HIGH,
+        ),
+        TodoItem(
+            id="3",
+            content="In Progress",
+            status=TodoStatus.IN_PROGRESS,
+            priority=TodoPriority.MEDIUM,
+        ),
+        TodoItem(
+            id="4",
+            content="High Priority",
+            status=TodoStatus.PENDING,
+            priority=TodoPriority.HIGH,
+        ),
+    ]
+
+    # Sort the todos
+    sorted_todos = sort_todos(todos)
+
+    # Check the order
+    assert sorted_todos[0].id == "3"  # In Progress should be first
+    assert sorted_todos[1].id == "4"  # High Priority Pending second
+    assert sorted_todos[2].id == "1"  # Low Priority Pending third
+    assert sorted_todos[3].id == "2"  # Completed last
+
+
+def test_todo_multiple_sessions(mock_context, tmp_path):
+    """Test that todos are isolated by session."""
+    # Create two different session IDs
+    session_id_1 = str(uuid.uuid4())
+    session_id_2 = str(uuid.uuid4())
+
+    # Set up contexts for both sessions
+    context_1 = mock.MagicMock(spec=AgentContext)
+    context_1.session_id = session_id_1
+
+    context_2 = mock.MagicMock(spec=AgentContext)
+    context_2.session_id = session_id_2
+
+    # Create a temporary directory for todos
+    todos_dir = tmp_path / "todos"
+    todos_dir.mkdir()
+
+    # Mock the get_todos_dir function
+    with mock.patch(
+        "heare.developer.tools.todos.get_todos_dir", return_value=todos_dir
+    ):
+        # Add a todo for session 1
+        todo_write(context_1, [{"content": "Session 1 Task"}])
+
+        # Add a todo for session 2
+        todo_write(context_2, [{"content": "Session 2 Task"}])
+
+        # Read todos for both sessions
+        result_1 = todo_read(context_1)
+        result_2 = todo_read(context_2)
+
+    # Check that each session has its own todos
+    assert "Session 1 Task" in result_1
+    assert "Session 2 Task" not in result_1
+
+    assert "Session 2 Task" in result_2
+    assert "Session 1 Task" not in result_2

--- a/tests/test_todo_tools_enhancements.py
+++ b/tests/test_todo_tools_enhancements.py
@@ -1,0 +1,200 @@
+"""
+Tests for the enhanced todo tools.
+"""
+
+import json
+import pytest
+from unittest.mock import MagicMock, patch
+
+from heare.developer.tools.todos import (
+    TodoItem,
+    TodoStatus,
+    TodoPriority,
+    todo_read,
+    todo_add,
+    todo_update,
+    todo_complete,
+    todo_delete,
+    format_todo_list,
+)
+
+
+@pytest.fixture
+def mock_context():
+    """Create a mock context with a session ID."""
+    context = MagicMock()
+    context.session_id = "test-session"
+    return context
+
+
+@pytest.fixture
+def sample_todos():
+    """Create a sample list of todos."""
+    return [
+        TodoItem(
+            id="1",
+            content="Implement todo tools",
+            status=TodoStatus.IN_PROGRESS,
+            priority=TodoPriority.HIGH,
+        ),
+        TodoItem(
+            id="2",
+            content="Write tests",
+            status=TodoStatus.PENDING,
+            priority=TodoPriority.MEDIUM,
+        ),
+        TodoItem(
+            id="3",
+            content="Update docs",
+            status=TodoStatus.COMPLETED,
+            priority=TodoPriority.LOW,
+        ),
+    ]
+
+
+def test_format_todo_list(sample_todos):
+    """Test that format_todo_list includes metadata."""
+    result = format_todo_list(sample_todos)
+    
+    # Check that the function returns a string with the expected content
+    assert "# Todo List" in result
+    assert "Implement todo tools" in result
+    assert "Write tests" in result
+    assert "Update docs" in result
+    
+    # Check that metadata is included
+    assert "## METADATA" in result
+    assert "```json" in result
+    
+    # Extract and parse the metadata
+    metadata_start = result.find("```json") + 7
+    metadata_end = result.find("```", metadata_start)
+    metadata_json = result[metadata_start:metadata_end].strip()
+    metadata = json.loads(metadata_json)
+    
+    # Verify metadata structure
+    assert "todos" in metadata
+    assert len(metadata["todos"]) == 3
+    assert metadata["todos"][0]["id"] == "1"
+    assert metadata["todos"][0]["content"] == "Implement todo tools"
+    assert metadata["todos"][0]["status"] == "in_progress"
+    assert metadata["todos"][0]["priority"] == "high"
+
+
+@patch("heare.developer.tools.todos.load_todos")
+@patch("heare.developer.tools.todos.save_todos")
+def test_todo_add(mock_save_todos, mock_load_todos, mock_context, sample_todos):
+    """Test adding a new todo."""
+    # Setup
+    mock_load_todos.return_value = sample_todos.copy()
+    
+    # Execute
+    result = todo_add(mock_context, "Review PR", "high")
+    
+    # Verify
+    assert "✅ Added todo" in result
+    assert "Review PR" in result
+    assert "high" in result
+    
+    # Check that save_todos was called with the correct arguments
+    args = mock_save_todos.call_args[0]
+    saved_todos = args[1]
+    assert len(saved_todos) == 4  # 3 original + 1 new
+    assert saved_todos[3].content == "Review PR"
+    assert saved_todos[3].priority == TodoPriority.HIGH
+    assert saved_todos[3].status == TodoStatus.PENDING
+
+
+@patch("heare.developer.tools.todos.load_todos")
+@patch("heare.developer.tools.todos.save_todos")
+def test_todo_update(mock_save_todos, mock_load_todos, mock_context, sample_todos):
+    """Test updating a todo."""
+    # Setup
+    mock_load_todos.return_value = sample_todos.copy()
+    
+    # Execute - update content and priority
+    result = todo_update(
+        mock_context, 
+        todo_id="2", 
+        content="Write comprehensive tests", 
+        priority="high"
+    )
+    
+    # Verify
+    assert "✅ Updated todo" in result
+    assert "Write comprehensive tests" in result
+    assert "priority: 'medium' → 'high'" in result
+    
+    # Check that save_todos was called with the correct arguments
+    args = mock_save_todos.call_args[0]
+    saved_todos = args[1]
+    updated_todo = next(todo for todo in saved_todos if todo.id == "2")
+    assert updated_todo.content == "Write comprehensive tests"
+    assert updated_todo.priority == TodoPriority.HIGH
+
+
+@patch("heare.developer.tools.todos.load_todos")
+@patch("heare.developer.tools.todos.save_todos")
+def test_todo_complete(mock_save_todos, mock_load_todos, mock_context, sample_todos):
+    """Test marking a todo as completed."""
+    # Setup
+    mock_load_todos.return_value = sample_todos.copy()
+    
+    # Execute
+    result = todo_complete(mock_context, todo_id="2")
+    
+    # Verify
+    assert "✅ Marked todo as completed" in result
+    assert "Write tests" in result
+    assert "status: 'pending' → 'completed'" in result
+    
+    # Check that save_todos was called with the correct arguments
+    args = mock_save_todos.call_args[0]
+    saved_todos = args[1]
+    completed_todo = next(todo for todo in saved_todos if todo.id == "2")
+    assert completed_todo.status == TodoStatus.COMPLETED
+
+
+@patch("heare.developer.tools.todos.load_todos")
+@patch("heare.developer.tools.todos.save_todos")
+def test_todo_delete(mock_save_todos, mock_load_todos, mock_context, sample_todos):
+    """Test deleting a todo."""
+    # Setup
+    mock_load_todos.return_value = sample_todos.copy()
+    
+    # Execute
+    result = todo_delete(mock_context, todo_id="1")
+    
+    # Verify
+    assert "✅ Deleted todo" in result
+    assert "Implement todo tools" in result
+    
+    # Check that save_todos was called with the correct arguments
+    args = mock_save_todos.call_args[0]
+    saved_todos = args[1]
+    assert len(saved_todos) == 2  # 3 original - 1 deleted
+    assert all(todo.id != "1" for todo in saved_todos)
+
+
+@patch("heare.developer.tools.todos.load_todos")
+def test_todo_read(mock_load_todos, mock_context, sample_todos):
+    """Test reading todos with metadata."""
+    # Setup
+    mock_load_todos.return_value = sample_todos.copy()
+    
+    # Execute
+    result = todo_read(mock_context)
+    
+    # Verify the result contains the todo list and metadata
+    assert "# Todo List" in result
+    assert "Implement todo tools" in result
+    assert "## METADATA" in result
+    
+    # Extract and verify metadata
+    metadata_start = result.find("```json") + 7
+    metadata_end = result.find("```", metadata_start)
+    metadata_json = result[metadata_start:metadata_end].strip()
+    metadata = json.loads(metadata_json)
+    
+    assert len(metadata["todos"]) == 3
+    assert metadata["todos"][0]["id"] == "1"  # First item should be the in_progress high priority task

--- a/tests/test_todo_tools_enhancements.py
+++ b/tests/test_todo_tools_enhancements.py
@@ -55,23 +55,23 @@ def sample_todos():
 def test_format_todo_list(sample_todos):
     """Test that format_todo_list includes metadata."""
     result = format_todo_list(sample_todos)
-    
+
     # Check that the function returns a string with the expected content
     assert "# Todo List" in result
     assert "Implement todo tools" in result
     assert "Write tests" in result
     assert "Update docs" in result
-    
+
     # Check that metadata is included
     assert "## METADATA" in result
     assert "```json" in result
-    
+
     # Extract and parse the metadata
     metadata_start = result.find("```json") + 7
     metadata_end = result.find("```", metadata_start)
     metadata_json = result[metadata_start:metadata_end].strip()
     metadata = json.loads(metadata_json)
-    
+
     # Verify metadata structure
     assert "todos" in metadata
     assert len(metadata["todos"]) == 3
@@ -87,15 +87,15 @@ def test_todo_add(mock_save_todos, mock_load_todos, mock_context, sample_todos):
     """Test adding a new todo."""
     # Setup
     mock_load_todos.return_value = sample_todos.copy()
-    
+
     # Execute
     result = todo_add(mock_context, "Review PR", "high")
-    
+
     # Verify
     assert "✅ Added todo" in result
     assert "Review PR" in result
     assert "high" in result
-    
+
     # Check that save_todos was called with the correct arguments
     args = mock_save_todos.call_args[0]
     saved_todos = args[1]
@@ -111,20 +111,17 @@ def test_todo_update(mock_save_todos, mock_load_todos, mock_context, sample_todo
     """Test updating a todo."""
     # Setup
     mock_load_todos.return_value = sample_todos.copy()
-    
+
     # Execute - update content and priority
     result = todo_update(
-        mock_context, 
-        todo_id="2", 
-        content="Write comprehensive tests", 
-        priority="high"
+        mock_context, todo_id="2", content="Write comprehensive tests", priority="high"
     )
-    
+
     # Verify
     assert "✅ Updated todo" in result
     assert "Write comprehensive tests" in result
     assert "priority: 'medium' → 'high'" in result
-    
+
     # Check that save_todos was called with the correct arguments
     args = mock_save_todos.call_args[0]
     saved_todos = args[1]
@@ -139,15 +136,15 @@ def test_todo_complete(mock_save_todos, mock_load_todos, mock_context, sample_to
     """Test marking a todo as completed."""
     # Setup
     mock_load_todos.return_value = sample_todos.copy()
-    
+
     # Execute
     result = todo_complete(mock_context, todo_id="2")
-    
+
     # Verify
     assert "✅ Marked todo as completed" in result
     assert "Write tests" in result
     assert "status: 'pending' → 'completed'" in result
-    
+
     # Check that save_todos was called with the correct arguments
     args = mock_save_todos.call_args[0]
     saved_todos = args[1]
@@ -161,14 +158,14 @@ def test_todo_delete(mock_save_todos, mock_load_todos, mock_context, sample_todo
     """Test deleting a todo."""
     # Setup
     mock_load_todos.return_value = sample_todos.copy()
-    
+
     # Execute
     result = todo_delete(mock_context, todo_id="1")
-    
+
     # Verify
     assert "✅ Deleted todo" in result
     assert "Implement todo tools" in result
-    
+
     # Check that save_todos was called with the correct arguments
     args = mock_save_todos.call_args[0]
     saved_todos = args[1]
@@ -181,20 +178,22 @@ def test_todo_read(mock_load_todos, mock_context, sample_todos):
     """Test reading todos with metadata."""
     # Setup
     mock_load_todos.return_value = sample_todos.copy()
-    
+
     # Execute
     result = todo_read(mock_context)
-    
+
     # Verify the result contains the todo list and metadata
     assert "# Todo List" in result
     assert "Implement todo tools" in result
     assert "## METADATA" in result
-    
+
     # Extract and verify metadata
     metadata_start = result.find("```json") + 7
     metadata_end = result.find("```", metadata_start)
     metadata_json = result[metadata_start:metadata_end].strip()
     metadata = json.loads(metadata_json)
-    
+
     assert len(metadata["todos"]) == 3
-    assert metadata["todos"][0]["id"] == "1"  # First item should be the in_progress high priority task
+    assert (
+        metadata["todos"][0]["id"] == "1"
+    )  # First item should be the in_progress high priority task


### PR DESCRIPTION
This PR implements todo list tools for the heare project, as specified in HDEV-55.

## Features
- : Read the current todo list for the session
- : Create or update todos in the current session
- Todo items with content, status, priority, and unique ID
- Status tracking (pending, in_progress, completed)
- Priority support (high, medium, low)
- Session isolation (todos are session-specific)
- Sorting by status and priority
- Visual diff when updating todos

## Implementation
- Todos are stored in JSON files in the ~/.local/share/heare/todos directory
- Each session has its own todo file named by session ID
- Comprehensive validation and error handling
- Added tests to ensure functionality works as expected

## Testing
Added comprehensive tests in  covering:
- Reading empty todo lists
- Creating and reading todos
- Updating existing todos
- Todo validation
- Proper sorting of todos
- Session isolation for todos

Closes #55