### PR TITLE
Fix github_api tool bug with string fields parameter

### DIFF
--- a/tests/test_github_api_tool.py
+++ b/tests/test_github_api_tool.py
@@ -1,0 +1,125 @@
+"""Tests for the github_api tool function."""
+
+from unittest.mock import patch, MagicMock
+import pytest
+
+from heare.developer.context import AgentContext
+from heare.developer.tools.github import github_api
+
+
+@pytest.fixture
+def mock_context():
+    """Create a mock agent context."""
+    return MagicMock(spec=AgentContext)
+
+
+@patch("heare.developer.tools.github._run_gh_command")
+def test_github_api_with_dict_fields(mock_run_gh, mock_context):
+    """Test github_api with dictionary fields parameter."""
+    # Setup mock response
+    mock_run_gh.return_value = {
+        "success": True,
+        "data": '{"status": "success", "data": {"id": 123, "name": "test"}}',
+    }
+
+    # Call with dictionary fields
+    result = github_api(
+        mock_context,
+        endpoint="repos/owner/repo/issues",
+        fields={"title": "Test Issue", "body": "Test Body"},
+    )
+
+    # Verify command construction
+    args = mock_run_gh.call_args[0][0]
+    assert "repos/owner/repo/issues" in args
+    assert "--field" in args
+    assert "title=Test Issue" in args[args.index("--field") + 1]
+    assert (
+        "body=Test Body" in args[args.index("--field", args.index("--field") + 1) + 1]
+    )
+
+    # Verify output formatting
+    assert "GitHub API: repos/owner/repo/issues" in result
+    assert "success" in result
+
+
+@patch("heare.developer.tools.github._run_gh_command")
+def test_github_api_with_string_fields(mock_run_gh, mock_context):
+    """Test github_api with JSON string fields parameter."""
+    # Setup mock response
+    mock_run_gh.return_value = {
+        "success": True,
+        "data": '{"status": "success", "data": {"id": 123, "name": "test"}}',
+    }
+
+    # Call with string fields (JSON)
+    result = github_api(
+        mock_context,
+        endpoint="repos/owner/repo/issues",
+        fields='{"title": "Test Issue", "body": "Test Body"}',
+    )
+
+    # Verify command construction
+    args = mock_run_gh.call_args[0][0]
+    assert "repos/owner/repo/issues" in args
+    assert "--field" in args
+    assert "title=Test Issue" in args[args.index("--field") + 1]
+    assert (
+        "body=Test Body" in args[args.index("--field", args.index("--field") + 1) + 1]
+    )
+
+    # Verify output formatting
+    assert "GitHub API: repos/owner/repo/issues" in result
+    assert "success" in result
+
+
+@patch("heare.developer.tools.github._run_gh_command")
+def test_github_api_with_invalid_string_fields(mock_run_gh, mock_context):
+    """Test github_api with invalid JSON string fields parameter."""
+    # Call with invalid JSON string
+    result = github_api(
+        mock_context, endpoint="repos/owner/repo/issues", fields='{"title": "broken'
+    )
+
+    # Verify error is returned
+    assert "Error: Unable to parse 'fields' as JSON" in result
+
+    # Ensure _run_gh_command was not called
+    mock_run_gh.assert_not_called()
+
+
+@patch("heare.developer.tools.github._run_gh_command")
+def test_github_api_with_non_dict_json(mock_run_gh, mock_context):
+    """Test github_api with JSON string that doesn't represent a dict."""
+    # Call with JSON array instead of object
+    result = github_api(
+        mock_context, endpoint="repos/owner/repo/issues", fields="[1, 2, 3]"
+    )
+
+    # Verify error is returned
+    assert "Error: 'fields' must be a dictionary" in result
+
+    # Ensure _run_gh_command was not called
+    mock_run_gh.assert_not_called()
+
+
+@patch("heare.developer.tools.github._run_gh_command")
+def test_github_api_without_fields(mock_run_gh, mock_context):
+    """Test github_api without fields parameter."""
+    # Setup mock response
+    mock_run_gh.return_value = {
+        "success": True,
+        "data": '{"status": "success"}',
+    }
+
+    # Call without fields
+    result = github_api(mock_context, endpoint="repos/owner/repo")
+
+    # Verify command construction
+    args = mock_run_gh.call_args[0][0]
+    assert "repos/owner/repo" in args
+    assert "--field" not in args
+
+    # Verify output formatting
+    assert "GitHub API: repos/owner/repo" in result
+    assert "success" in result

--- a/tests/test_history_metadata.py
+++ b/tests/test_history_metadata.py
@@ -1,0 +1,139 @@
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from heare.developer.context import AgentContext
+from heare.developer.sandbox import SandboxMode
+from heare.developer.user_interface import UserInterface
+
+
+class TestHistoryMetadata(unittest.TestCase):
+    def setUp(self):
+        # Create a temporary directory for history files
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.history_dir = Path(self.temp_dir.name)
+
+        # Create model_spec
+        self.model_spec = {
+            "title": "test-model",
+            "pricing": {"input": 1.0, "output": 1.0},
+            "cache_pricing": {"write": 1.0, "read": 0.1},
+            "max_tokens": 1000,
+            "context_window": 2000,
+        }
+
+        # Create a mock user interface
+        self.user_interface = MagicMock(spec=UserInterface)
+        self.user_interface.permission_callback = MagicMock(return_value=True)
+        self.user_interface.permission_rendering_callback = MagicMock(return_value=True)
+
+        # Create agent context
+        self.agent_context = AgentContext.create(
+            model_spec=self.model_spec,
+            sandbox_mode=SandboxMode.ALLOW_ALL,
+            sandbox_contents=[os.getcwd()],
+            user_interface=self.user_interface,
+        )
+
+        # Mock chat history
+        self.chat_history = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+        ]
+
+    def tearDown(self):
+        # Cleanup the temporary directory
+        self.temp_dir.cleanup()
+
+    @patch("pathlib.Path.home")
+    def test_flush_adds_metadata(self, mock_home):
+        # Setup mock home to point to our temp directory
+        mock_home.return_value = self.history_dir
+
+        # Flush the conversation
+        self.agent_context.flush(self.chat_history)
+
+        # Get the path to the saved history file
+        history_file = (
+            self.history_dir
+            / ".hdev"
+            / "history"
+            / self.agent_context.session_id
+            / "root.json"
+        )
+
+        # Check if the file exists
+        self.assertTrue(history_file.exists())
+
+        # Load the file
+        with open(history_file, "r") as f:
+            data = json.load(f)
+
+        # Verify metadata fields exist
+        self.assertIn("metadata", data)
+        self.assertIn("created_at", data["metadata"])
+        self.assertIn("last_updated", data["metadata"])
+        self.assertIn("root_dir", data["metadata"])
+
+        # Verify created_at and last_updated are valid ISO format dates
+        try:
+            created_at = datetime.fromisoformat(data["metadata"]["created_at"])
+            last_updated = datetime.fromisoformat(data["metadata"]["last_updated"])
+            self.assertIsNotNone(created_at)
+            self.assertIsNotNone(last_updated)
+        except ValueError:
+            self.fail("Dates are not in valid ISO format")
+
+        # Verify root_dir is a string and not empty
+        self.assertIsInstance(data["metadata"]["root_dir"], str)
+        self.assertTrue(len(data["metadata"]["root_dir"]) > 0)
+
+    @patch("pathlib.Path.home")
+    def test_update_preserves_created_at(self, mock_home):
+        # Setup mock home to point to our temp directory
+        mock_home.return_value = self.history_dir
+
+        # Flush the conversation first time
+        self.agent_context.flush(self.chat_history)
+
+        # Get the path to the saved history file
+        history_file = (
+            self.history_dir
+            / ".hdev"
+            / "history"
+            / self.agent_context.session_id
+            / "root.json"
+        )
+
+        # Load the file to get original created_at
+        with open(history_file, "r") as f:
+            original_data = json.load(f)
+        original_created_at = original_data["metadata"]["created_at"]
+
+        # Wait a moment to ensure timestamps would be different
+        import time
+
+        time.sleep(0.1)
+
+        # Update chat history and flush again
+        updated_chat_history = self.chat_history.copy()
+        updated_chat_history.append({"role": "user", "content": "How are you?"})
+        self.agent_context.flush(updated_chat_history)
+
+        # Load the file again
+        with open(history_file, "r") as f:
+            updated_data = json.load(f)
+
+        # Verify created_at is preserved but last_updated is changed
+        self.assertEqual(updated_data["metadata"]["created_at"], original_created_at)
+        self.assertNotEqual(
+            updated_data["metadata"]["last_updated"], original_created_at
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug Fix for  Tool

This PR fixes the issue described in HDEV-56, where the  tool would crash with an AttributeError when a string was passed to the  parameter.

### Changes
- Updated type annotations to accept both Dict and str for the fields parameter
- Added robust type checking and JSON parsing for string inputs
- Implemented proper error handling with descriptive error messages
- Added comprehensive tests to verify all scenarios

### Implementation Details
The solution makes the tool more robust while maintaining backward compatibility:
1. First checks if  is already a dictionary
2. If it's a string, attempts to parse it as JSON to convert to a dictionary
3. Returns an appropriate error message if conversion fails

### Testing
Added a new test file  with tests that cover:
- Using dictionary fields (existing behavior)
- Using valid JSON string fields (new capability)
- Handling invalid JSON strings
- Handling non-dictionary JSON
- Behavior without fields parameter

Fixes HDEV-56