### PR TITLE
Fix tool spec invocation crash (HDEV-40)

### DIFF
--- a/heare/developer/agent.py
+++ b/heare/developer/agent.py
@@ -436,11 +436,18 @@ def run(
             if final_message.stop_reason == "tool_use":
                 for part in final_message.content:
                     if part.type == "tool_use":
-                        user_interface.handle_tool_use(part.name, part.input)
                         try:
+                            # Safely extract tool information, handling potential missing attributes
+                            tool_name = getattr(part, 'name', 'unknown_tool')
+                            tool_input = getattr(part, 'input', {})
+                            
+                            # Log the tool use
+                            user_interface.handle_tool_use(tool_name, tool_input)
+                            
+                            # Invoke the tool
                             result = toolbox.invoke_agent_tool(part)
                             agent_context.tool_result_buffer.append(result)
-                            user_interface.handle_tool_result(part.name, result)
+                            user_interface.handle_tool_result(tool_name, result)
                         except DoSomethingElseError:
                             # Handle "do something else" workflow:
                             # 1. Remove the last assistant message
@@ -485,6 +492,22 @@ def run(
                             # Skip to the next iteration to immediately process the updated chat history
                             # instead of breaking out of the loop which would wait for next user input
                             continue
+                        except Exception as e:
+                            # Handle any other exceptions during tool invocation
+                            error_message = f"Error invoking tool: {str(e)}"
+                            user_interface.handle_system_message(
+                                f"[bold red]{error_message}[/bold red]"
+                            )
+                            result = {
+                                "type": "tool_result",
+                                "tool_use_id": getattr(part, 'id', 'unknown_id'),
+                                "content": error_message,
+                            }
+                            agent_context.tool_result_buffer.append(result)
+                            user_interface.handle_tool_result(
+                                getattr(part, 'name', 'unknown_tool'), 
+                                result
+                            )
             elif final_message.stop_reason == "max_tokens":
                 user_interface.handle_assistant_message(
                     "[bold red]Hit max tokens.[/bold red]"

--- a/heare/developer/agent.py
+++ b/heare/developer/agent.py
@@ -438,12 +438,12 @@ def run(
                     if part.type == "tool_use":
                         try:
                             # Safely extract tool information, handling potential missing attributes
-                            tool_name = getattr(part, 'name', 'unknown_tool')
-                            tool_input = getattr(part, 'input', {})
-                            
+                            tool_name = getattr(part, "name", "unknown_tool")
+                            tool_input = getattr(part, "input", {})
+
                             # Log the tool use
                             user_interface.handle_tool_use(tool_name, tool_input)
-                            
+
                             # Invoke the tool
                             result = toolbox.invoke_agent_tool(part)
                             agent_context.tool_result_buffer.append(result)
@@ -500,13 +500,12 @@ def run(
                             )
                             result = {
                                 "type": "tool_result",
-                                "tool_use_id": getattr(part, 'id', 'unknown_id'),
+                                "tool_use_id": getattr(part, "id", "unknown_id"),
                                 "content": error_message,
                             }
                             agent_context.tool_result_buffer.append(result)
                             user_interface.handle_tool_result(
-                                getattr(part, 'name', 'unknown_tool'), 
-                                result
+                                getattr(part, "name", "unknown_tool"), result
                             )
             elif final_message.stop_reason == "max_tokens":
                 user_interface.handle_assistant_message(

--- a/heare/developer/toolbox.py
+++ b/heare/developer/toolbox.py
@@ -159,17 +159,15 @@ class Toolbox:
 
         try:
             # Ensure tool_use has the expected attributes before proceeding
-            if not hasattr(tool_use, 'name') or not hasattr(tool_use, 'input'):
-                tool_use_id = getattr(tool_use, 'id', 'unknown_id')
+            if not hasattr(tool_use, "name") or not hasattr(tool_use, "input"):
+                tool_use_id = getattr(tool_use, "id", "unknown_id")
                 return {
                     "type": "tool_result",
                     "tool_use_id": tool_use_id,
-                    "content": f"Invalid tool specification: missing required attributes",
-                    "params": {
-                        "error": "invalid_tool_spec"
-                    }
+                    "content": "Invalid tool specification: missing required attributes",
+                    "params": {"error": "invalid_tool_spec"},
                 }
-                
+
             # Convert agent tools to a list matching tools format
             return invoke_tool(self.context, tool_use, tools=self.agent_tools)
         except DoSomethingElseError:
@@ -177,16 +175,13 @@ class Toolbox:
             raise
         except Exception as e:
             # Handle any other exceptions that might occur
-            tool_use_id = getattr(tool_use, 'id', 'unknown_id')
-            tool_name = getattr(tool_use, 'name', 'unknown_tool')
+            tool_use_id = getattr(tool_use, "id", "unknown_id")
+            tool_name = getattr(tool_use, "name", "unknown_tool")
             return {
                 "type": "tool_result",
                 "tool_use_id": tool_use_id,
                 "content": f"Error invoking tool '{tool_name}': {str(e)}",
-                "params": {
-                    "error": "tool_invocation_error",
-                    "details": str(e)
-                }
+                "params": {"error": "tool_invocation_error", "details": str(e)},
             }
 
     # CLI Tools

--- a/heare/developer/toolbox.py
+++ b/heare/developer/toolbox.py
@@ -158,11 +158,36 @@ class Toolbox:
         from .sandbox import DoSomethingElseError
 
         try:
+            # Ensure tool_use has the expected attributes before proceeding
+            if not hasattr(tool_use, 'name') or not hasattr(tool_use, 'input'):
+                tool_use_id = getattr(tool_use, 'id', 'unknown_id')
+                return {
+                    "type": "tool_result",
+                    "tool_use_id": tool_use_id,
+                    "content": f"Invalid tool specification: missing required attributes",
+                    "params": {
+                        "error": "invalid_tool_spec"
+                    }
+                }
+                
             # Convert agent tools to a list matching tools format
             return invoke_tool(self.context, tool_use, tools=self.agent_tools)
         except DoSomethingElseError:
             # Let the exception propagate up to the agent to be handled
             raise
+        except Exception as e:
+            # Handle any other exceptions that might occur
+            tool_use_id = getattr(tool_use, 'id', 'unknown_id')
+            tool_name = getattr(tool_use, 'name', 'unknown_tool')
+            return {
+                "type": "tool_result",
+                "tool_use_id": tool_use_id,
+                "content": f"Error invoking tool '{tool_name}': {str(e)}",
+                "params": {
+                    "error": "tool_invocation_error",
+                    "details": str(e)
+                }
+            }
 
     # CLI Tools
     def _help(self, user_interface, sandbox, user_input, *args, **kwargs):

--- a/heare/developer/tools/framework.py
+++ b/heare/developer/tools/framework.py
@@ -130,21 +130,21 @@ def invoke_tool(context: "AgentContext", tool_use, tools: List[Callable] = None)
             "tool_use_id": "unknown_id",
             "content": "Invalid tool specification: tool_use is None",
         }
-    
+
     # Check if tool_use has the necessary attributes
-    if not hasattr(tool_use, 'name') or not hasattr(tool_use, 'input'):
-        tool_use_id = getattr(tool_use, 'id', 'unknown_id')
+    if not hasattr(tool_use, "name") or not hasattr(tool_use, "input"):
+        tool_use_id = getattr(tool_use, "id", "unknown_id")
         return {
             "type": "tool_result",
             "tool_use_id": tool_use_id,
             "content": "Invalid tool specification: missing required attributes 'name' or 'input'",
         }
-    
+
     # Extract tool information, now that we know the attributes exist
     try:
         function_name = tool_use.name
         arguments = tool_use.input
-        tool_use_id = getattr(tool_use, 'id', 'unknown_id')
+        tool_use_id = getattr(tool_use, "id", "unknown_id")
     except (AttributeError, TypeError) as e:
         # This should never happen due to the checks above, but just in case
         return {

--- a/tests/test_tool_spec_simple.py
+++ b/tests/test_tool_spec_simple.py
@@ -1,6 +1,7 @@
 """
 Simple test script for unexpected tool specs that doesn't rely on pytest.
 """
+
 import sys
 import traceback
 from unittest.mock import MagicMock
@@ -10,56 +11,70 @@ from heare.developer.toolbox import Toolbox
 from heare.developer.context import AgentContext
 from heare.developer.sandbox import SandboxMode
 
+
 def test_invoke_tool_with_empty_toolspec():
     """Test invoking a tool with an empty or invalid tool specification"""
     print("Testing invoke_tool with empty tool spec...")
     context = MagicMock()
-    
+
     # Test with None
     result = invoke_tool(context, None)
-    assert "Invalid tool specification" in result["content"], "Should handle None gracefully"
+    assert (
+        "Invalid tool specification" in result["content"]
+    ), "Should handle None gracefully"
     print("✅ Test with None passed")
-    
+
     # Test with dict instead of proper tool_use object
     result = invoke_tool(context, {"type": "tool_use"})
-    assert "Invalid tool specification" in result["content"], "Should handle dict gracefully"
+    assert (
+        "Invalid tool specification" in result["content"]
+    ), "Should handle dict gracefully"
     print("✅ Test with dict passed")
-    
+
     # Test with MagicMock missing required attributes
     mock_tool = MagicMock()
     mock_tool.type = "tool_use"
     # MagicMock has special behavior - we need to explicitly set name/input to None
     del mock_tool.name
     del mock_tool.input
-    
+
     print(f"Has name attribute: {hasattr(mock_tool, 'name')}")
     print(f"Has input attribute: {hasattr(mock_tool, 'input')}")
     result = invoke_tool(context, mock_tool)
     print(f"Result content: {result['content']}")
-    assert "Invalid tool specification" in result["content"], "Should handle missing attributes gracefully"
+    assert (
+        "Invalid tool specification" in result["content"]
+    ), "Should handle missing attributes gracefully"
     print("✅ Test with MagicMock missing attributes passed")
+
 
 def test_toolbox_invoke_agent_tool():
     """Test Toolbox.invoke_agent_tool with invalid tool specs"""
     print("Testing Toolbox.invoke_agent_tool with invalid tool specs...")
-    
+
     # Create a minimal context
     user_interface = MagicMock()
     context = AgentContext.create(
-        model_spec={"title": "test_model", "max_tokens": 1000, "pricing": {"input": 0.25, "output": 1.25}},
+        model_spec={
+            "title": "test_model",
+            "max_tokens": 1000,
+            "pricing": {"input": 0.25, "output": 1.25},
+        },
         sandbox_mode=SandboxMode.ALLOW_ALL,
         user_interface=user_interface,
         sandbox_contents=[],  # Empty list for sandbox contents
     )
-    
+
     # Create a toolbox
     toolbox = Toolbox(context)
-    
+
     # Test with None
     result = toolbox.invoke_agent_tool(None)
-    assert "Invalid tool specification" in result["content"], "Should handle None gracefully"
+    assert (
+        "Invalid tool specification" in result["content"]
+    ), "Should handle None gracefully"
     print("✅ Test with None passed")
-    
+
     # Test with malformed tool object
     malformed_tool = MagicMock()
     malformed_tool.type = "tool_use"
@@ -67,23 +82,30 @@ def test_toolbox_invoke_agent_tool():
     # Explicitly remove name and input attributes
     del malformed_tool.name
     del malformed_tool.input
-    
-    print(f"Malformed tool - Has name: {hasattr(malformed_tool, 'name')}, Has input: {hasattr(malformed_tool, 'input')}")
+
+    print(
+        f"Malformed tool - Has name: {hasattr(malformed_tool, 'name')}, Has input: {hasattr(malformed_tool, 'input')}"
+    )
     result = toolbox.invoke_agent_tool(malformed_tool)
     print(f"Malformed tool result: {result['content']}")
-    assert "Invalid tool specification" in result["content"], "Should handle malformed tool gracefully"
+    assert (
+        "Invalid tool specification" in result["content"]
+    ), "Should handle malformed tool gracefully"
     print("✅ Test with malformed tool passed")
-    
+
     # Test with unknown tool
     unknown_tool = MagicMock()
     unknown_tool.type = "tool_use"
     unknown_tool.id = "tu_789"
     unknown_tool.name = "nonexistent_tool"  # This tool doesn't exist
     unknown_tool.input = {}
-    
+
     result = toolbox.invoke_agent_tool(unknown_tool)
-    assert "Unknown function" in result["content"], "Should handle unknown tool gracefully" 
+    assert (
+        "Unknown function" in result["content"]
+    ), "Should handle unknown tool gracefully"
     print("✅ Test with unknown tool passed")
+
 
 if __name__ == "__main__":
     try:

--- a/tests/test_tool_spec_simple.py
+++ b/tests/test_tool_spec_simple.py
@@ -1,0 +1,97 @@
+"""
+Simple test script for unexpected tool specs that doesn't rely on pytest.
+"""
+import sys
+import traceback
+from unittest.mock import MagicMock
+
+from heare.developer.tools.framework import invoke_tool
+from heare.developer.toolbox import Toolbox
+from heare.developer.context import AgentContext
+from heare.developer.sandbox import SandboxMode
+
+def test_invoke_tool_with_empty_toolspec():
+    """Test invoking a tool with an empty or invalid tool specification"""
+    print("Testing invoke_tool with empty tool spec...")
+    context = MagicMock()
+    
+    # Test with None
+    result = invoke_tool(context, None)
+    assert "Invalid tool specification" in result["content"], "Should handle None gracefully"
+    print("✅ Test with None passed")
+    
+    # Test with dict instead of proper tool_use object
+    result = invoke_tool(context, {"type": "tool_use"})
+    assert "Invalid tool specification" in result["content"], "Should handle dict gracefully"
+    print("✅ Test with dict passed")
+    
+    # Test with MagicMock missing required attributes
+    mock_tool = MagicMock()
+    mock_tool.type = "tool_use"
+    # MagicMock has special behavior - we need to explicitly set name/input to None
+    del mock_tool.name
+    del mock_tool.input
+    
+    print(f"Has name attribute: {hasattr(mock_tool, 'name')}")
+    print(f"Has input attribute: {hasattr(mock_tool, 'input')}")
+    result = invoke_tool(context, mock_tool)
+    print(f"Result content: {result['content']}")
+    assert "Invalid tool specification" in result["content"], "Should handle missing attributes gracefully"
+    print("✅ Test with MagicMock missing attributes passed")
+
+def test_toolbox_invoke_agent_tool():
+    """Test Toolbox.invoke_agent_tool with invalid tool specs"""
+    print("Testing Toolbox.invoke_agent_tool with invalid tool specs...")
+    
+    # Create a minimal context
+    user_interface = MagicMock()
+    context = AgentContext.create(
+        model_spec={"title": "test_model", "max_tokens": 1000, "pricing": {"input": 0.25, "output": 1.25}},
+        sandbox_mode=SandboxMode.ALLOW_ALL,
+        user_interface=user_interface,
+        sandbox_contents=[],  # Empty list for sandbox contents
+    )
+    
+    # Create a toolbox
+    toolbox = Toolbox(context)
+    
+    # Test with None
+    result = toolbox.invoke_agent_tool(None)
+    assert "Invalid tool specification" in result["content"], "Should handle None gracefully"
+    print("✅ Test with None passed")
+    
+    # Test with malformed tool object
+    malformed_tool = MagicMock()
+    malformed_tool.type = "tool_use"
+    malformed_tool.id = "tu_456"
+    # Explicitly remove name and input attributes
+    del malformed_tool.name
+    del malformed_tool.input
+    
+    print(f"Malformed tool - Has name: {hasattr(malformed_tool, 'name')}, Has input: {hasattr(malformed_tool, 'input')}")
+    result = toolbox.invoke_agent_tool(malformed_tool)
+    print(f"Malformed tool result: {result['content']}")
+    assert "Invalid tool specification" in result["content"], "Should handle malformed tool gracefully"
+    print("✅ Test with malformed tool passed")
+    
+    # Test with unknown tool
+    unknown_tool = MagicMock()
+    unknown_tool.type = "tool_use"
+    unknown_tool.id = "tu_789"
+    unknown_tool.name = "nonexistent_tool"  # This tool doesn't exist
+    unknown_tool.input = {}
+    
+    result = toolbox.invoke_agent_tool(unknown_tool)
+    assert "Unknown function" in result["content"], "Should handle unknown tool gracefully" 
+    print("✅ Test with unknown tool passed")
+
+if __name__ == "__main__":
+    try:
+        test_invoke_tool_with_empty_toolspec()
+        test_toolbox_invoke_agent_tool()
+        print("\n🎉 All tests passed!")
+        sys.exit(0)
+    except Exception as e:
+        print(f"\n❌ Test failed: {e}")
+        traceback.print_exc()
+        sys.exit(1)

--- a/tests/test_unexpected_tool_spec.py
+++ b/tests/test_unexpected_tool_spec.py
@@ -1,0 +1,137 @@
+import pytest
+import json
+from unittest.mock import MagicMock, patch
+from anthropic.types import ContentBlockDeltaEvent, Message, TextBlock, ToolResultBlock, ToolUseBlock
+
+from heare.developer.agent import run
+from heare.developer.context import AgentContext
+from heare.developer.sandbox import SandboxMode, DoSomethingElseError
+from heare.developer.tools.framework import invoke_tool
+
+
+def create_mock_response_with_unknown_tool():
+    """Create a mock response with an unknown tool_spec invocation"""
+    # Create a response object that simulates an unknown tool invocation
+    mock_response = MagicMock()
+    # Set up the get_final_message to return a message with an unknown tool use
+    final_message = Message(
+        id="msg_123",
+        content=[
+            ToolUseBlock(
+                type="tool_use",
+                id="tu_123",
+                name="unknown_tool",  # This tool doesn't exist in our toolbox
+                input={"param": "value"}
+            )
+        ],
+        model="claude-3-haiku-20240307",
+        role="assistant",
+        stop_reason="tool_use",
+        stop_sequence=None,
+        type="message",
+        usage=MagicMock()
+    )
+    mock_response.get_final_message.return_value = final_message
+    return mock_response
+
+
+def create_mock_response_with_malformed_tool():
+    """Create a mock response with a malformed tool_spec invocation"""
+    # Create a response object that simulates a malformed tool invocation
+    mock_response = MagicMock()
+    # Create a custom tool block that is missing required fields
+    malformed_tool = MagicMock()
+    malformed_tool.type = "tool_use"
+    malformed_tool.id = "tu_456"
+    # Intentionally missing name and input attributes
+    
+    # Set up the final message
+    final_message = Message(
+        id="msg_456",
+        content=[malformed_tool],
+        model="claude-3-haiku-20240307",
+        role="assistant",
+        stop_reason="tool_use",
+        stop_sequence=None,
+        type="message",
+        usage=MagicMock()
+    )
+    mock_response.get_final_message.return_value = final_message
+    return mock_response
+
+
+@patch("anthropic.resources.messages.Messages.stream")
+def test_unknown_tool_handled_gracefully(mock_stream):
+    """Test that the agent handles unknown tools gracefully"""
+    # Set up the mock stream to return a response with an unknown tool
+    mock_stream.return_value.__enter__.return_value = create_mock_response_with_unknown_tool()
+    
+    # Create minimal context for testing
+    user_interface = MagicMock()
+    context = AgentContext.create(
+        model_spec={"title": "claude-3-haiku-20240307", "max_tokens": 1000, "pricing": {"input": 0.25, "output": 1.25}},
+        sandbox_mode=SandboxMode.ALLOW_ALL,
+        user_interface=user_interface,
+    )
+    
+    # Add a message to the chat history
+    context.chat_history.append({"role": "user", "content": "Use a tool"})
+    
+    # Run the agent
+    run(agent_context=context, single_response=True)
+    
+    # Check that no exception was raised and the error was handled
+    # Verify the assistant reported an unknown function error
+    assert user_interface.handle_tool_result.called
+    tool_result_args = user_interface.handle_tool_result.call_args[0]
+    assert "unknown_tool" == tool_result_args[0]  # First arg is the tool name
+    assert "Unknown function" in tool_result_args[1]["content"]  # Error content
+
+
+@patch("anthropic.resources.messages.Messages.stream")
+def test_malformed_tool_spec_handled_gracefully(mock_stream):
+    """Test that the agent handles malformed tool specifications gracefully"""
+    # Set up the mock stream to return a response with a malformed tool
+    mock_stream.return_value.__enter__.return_value = create_mock_response_with_malformed_tool()
+    
+    # Create minimal context for testing
+    user_interface = MagicMock()
+    context = AgentContext.create(
+        model_spec={"title": "claude-3-haiku-20240307", "max_tokens": 1000, "pricing": {"input": 0.25, "output": 1.25}},
+        sandbox_mode=SandboxMode.ALLOW_ALL,
+        user_interface=user_interface,
+    )
+    
+    # Add a message to the chat history
+    context.chat_history.append({"role": "user", "content": "Use a malformed tool"})
+    
+    # Run the agent - should not crash
+    run(agent_context=context, single_response=True)
+    
+    # Verify the assistant handled the malformed tool gracefully
+    assert user_interface.handle_tool_result.called
+    # Tool name should default to "unknown_tool" when missing
+    assert "unknown_tool" in user_interface.handle_tool_result.call_args[0][0]
+    # Check that error message mentions invalid or missing attributes
+    result_content = user_interface.handle_tool_result.call_args[0][1]["content"]
+    assert "missing" in result_content.lower() or "invalid" in result_content.lower()
+
+
+def test_invoke_tool_with_empty_toolspec():
+    """Test invoking a tool with an empty or invalid tool specification"""
+    context = MagicMock()
+    
+    # Test with None
+    result = invoke_tool(context, None)
+    assert "Invalid tool specification" in result["content"]
+    
+    # Test with dict instead of proper tool_use object
+    result = invoke_tool(context, {"type": "tool_use"})
+    assert "Invalid tool specification" in result["content"]
+    
+    # Test with MagicMock missing required attributes
+    mock_tool = MagicMock()
+    mock_tool.type = "tool_use"
+    # Intentionally missing name and input
+    result = invoke_tool(context, mock_tool)
+    assert "Invalid tool specification" in result["content"]

--- a/tests/test_unexpected_tool_spec.py
+++ b/tests/test_unexpected_tool_spec.py
@@ -1,11 +1,9 @@
-import pytest
-import json
 from unittest.mock import MagicMock, patch
-from anthropic.types import ContentBlockDeltaEvent, Message, TextBlock, ToolResultBlock, ToolUseBlock
+from anthropic.types import Message, ToolUseBlock
 
 from heare.developer.agent import run
 from heare.developer.context import AgentContext
-from heare.developer.sandbox import SandboxMode, DoSomethingElseError
+from heare.developer.sandbox import SandboxMode
 from heare.developer.tools.framework import invoke_tool
 
 
@@ -21,7 +19,7 @@ def create_mock_response_with_unknown_tool():
                 type="tool_use",
                 id="tu_123",
                 name="unknown_tool",  # This tool doesn't exist in our toolbox
-                input={"param": "value"}
+                input={"param": "value"},
             )
         ],
         model="claude-3-haiku-20240307",
@@ -29,7 +27,7 @@ def create_mock_response_with_unknown_tool():
         stop_reason="tool_use",
         stop_sequence=None,
         type="message",
-        usage=MagicMock()
+        usage=MagicMock(),
     )
     mock_response.get_final_message.return_value = final_message
     return mock_response
@@ -44,7 +42,7 @@ def create_mock_response_with_malformed_tool():
     malformed_tool.type = "tool_use"
     malformed_tool.id = "tu_456"
     # Intentionally missing name and input attributes
-    
+
     # Set up the final message
     final_message = Message(
         id="msg_456",
@@ -54,7 +52,7 @@ def create_mock_response_with_malformed_tool():
         stop_reason="tool_use",
         stop_sequence=None,
         type="message",
-        usage=MagicMock()
+        usage=MagicMock(),
     )
     mock_response.get_final_message.return_value = final_message
     return mock_response
@@ -64,22 +62,28 @@ def create_mock_response_with_malformed_tool():
 def test_unknown_tool_handled_gracefully(mock_stream):
     """Test that the agent handles unknown tools gracefully"""
     # Set up the mock stream to return a response with an unknown tool
-    mock_stream.return_value.__enter__.return_value = create_mock_response_with_unknown_tool()
-    
+    mock_stream.return_value.__enter__.return_value = (
+        create_mock_response_with_unknown_tool()
+    )
+
     # Create minimal context for testing
     user_interface = MagicMock()
     context = AgentContext.create(
-        model_spec={"title": "claude-3-haiku-20240307", "max_tokens": 1000, "pricing": {"input": 0.25, "output": 1.25}},
+        model_spec={
+            "title": "claude-3-haiku-20240307",
+            "max_tokens": 1000,
+            "pricing": {"input": 0.25, "output": 1.25},
+        },
         sandbox_mode=SandboxMode.ALLOW_ALL,
         user_interface=user_interface,
     )
-    
+
     # Add a message to the chat history
     context.chat_history.append({"role": "user", "content": "Use a tool"})
-    
+
     # Run the agent
     run(agent_context=context, single_response=True)
-    
+
     # Check that no exception was raised and the error was handled
     # Verify the assistant reported an unknown function error
     assert user_interface.handle_tool_result.called
@@ -92,22 +96,28 @@ def test_unknown_tool_handled_gracefully(mock_stream):
 def test_malformed_tool_spec_handled_gracefully(mock_stream):
     """Test that the agent handles malformed tool specifications gracefully"""
     # Set up the mock stream to return a response with a malformed tool
-    mock_stream.return_value.__enter__.return_value = create_mock_response_with_malformed_tool()
-    
+    mock_stream.return_value.__enter__.return_value = (
+        create_mock_response_with_malformed_tool()
+    )
+
     # Create minimal context for testing
     user_interface = MagicMock()
     context = AgentContext.create(
-        model_spec={"title": "claude-3-haiku-20240307", "max_tokens": 1000, "pricing": {"input": 0.25, "output": 1.25}},
+        model_spec={
+            "title": "claude-3-haiku-20240307",
+            "max_tokens": 1000,
+            "pricing": {"input": 0.25, "output": 1.25},
+        },
         sandbox_mode=SandboxMode.ALLOW_ALL,
         user_interface=user_interface,
     )
-    
+
     # Add a message to the chat history
     context.chat_history.append({"role": "user", "content": "Use a malformed tool"})
-    
+
     # Run the agent - should not crash
     run(agent_context=context, single_response=True)
-    
+
     # Verify the assistant handled the malformed tool gracefully
     assert user_interface.handle_tool_result.called
     # Tool name should default to "unknown_tool" when missing
@@ -120,15 +130,15 @@ def test_malformed_tool_spec_handled_gracefully(mock_stream):
 def test_invoke_tool_with_empty_toolspec():
     """Test invoking a tool with an empty or invalid tool specification"""
     context = MagicMock()
-    
+
     # Test with None
     result = invoke_tool(context, None)
     assert "Invalid tool specification" in result["content"]
-    
+
     # Test with dict instead of proper tool_use object
     result = invoke_tool(context, {"type": "tool_use"})
     assert "Invalid tool specification" in result["content"]
-    
+
     # Test with MagicMock missing required attributes
     mock_tool = MagicMock()
     mock_tool.type = "tool_use"

--- a/tests/test_unexpected_tool_spec.py
+++ b/tests/test_unexpected_tool_spec.py
@@ -1,130 +1,64 @@
-from unittest.mock import MagicMock, patch
-from anthropic.types import Message, ToolUseBlock
-
-from heare.developer.agent import run
-from heare.developer.context import AgentContext
-from heare.developer.sandbox import SandboxMode
+from unittest.mock import MagicMock
 from heare.developer.tools.framework import invoke_tool
+from heare.developer.toolbox import Toolbox
 
 
-def create_mock_response_with_unknown_tool():
-    """Create a mock response with an unknown tool_spec invocation"""
-    # Create a response object that simulates an unknown tool invocation
-    mock_response = MagicMock()
-    # Set up the get_final_message to return a message with an unknown tool use
-    final_message = Message(
-        id="msg_123",
-        content=[
-            ToolUseBlock(
-                type="tool_use",
-                id="tu_123",
-                name="unknown_tool",  # This tool doesn't exist in our toolbox
-                input={"param": "value"},
-            )
-        ],
-        model="claude-3-haiku-20240307",
-        role="assistant",
-        stop_reason="tool_use",
-        stop_sequence=None,
-        type="message",
-        usage=MagicMock(),
+def test_unknown_tool_handled_gracefully():
+    """Test that the toolbox handles unknown tools gracefully"""
+    # Create a context mock
+    context = MagicMock()
+
+    # Create a toolbox with no tools
+    toolbox = Toolbox(context, [])
+
+    # Create a tool specification for an unknown tool
+    unknown_tool = MagicMock()
+    unknown_tool.name = "unknown_tool"
+    unknown_tool.id = "tu_123"
+    unknown_tool.input = {"param": "value"}
+    unknown_tool.type = "tool_use"
+
+    # Try to execute the unknown tool
+    result = toolbox.invoke_agent_tool(unknown_tool)
+
+    # Check that the result indicates an unknown function error
+    assert result["type"] == "tool_result"
+    assert result["tool_use_id"] == "tu_123"
+    assert "Unknown function" in result["content"]
+    assert "unknown_tool" in result["content"]
+
+
+def test_malformed_tool_spec_handled_gracefully():
+    """Test that the toolbox handles malformed tool specifications gracefully"""
+    # Create a context mock
+    context = MagicMock()
+
+    # Create a toolbox with no tools
+    toolbox = Toolbox(context, [])
+
+    # Create a malformed tool mock that will raise AttributeError for 'name' and 'input'
+    class MalformedTool:
+        type = "tool_use"
+        id = "tu_456"
+
+        def __getattribute__(self, name):
+            if name in ("name", "input"):
+                raise AttributeError(
+                    f"'{type(self).__name__}' object has no attribute '{name}'"
+                )
+            return super().__getattribute__(name)
+
+    malformed_tool = MalformedTool()
+
+    # Try to execute the malformed tool
+    result = toolbox.invoke_agent_tool(malformed_tool)
+
+    # Check that the result indicates an error about missing attributes
+    assert result["type"] == "tool_result"
+    assert result["tool_use_id"] == "tu_456"
+    assert (
+        "missing" in result["content"].lower() or "invalid" in result["content"].lower()
     )
-    mock_response.get_final_message.return_value = final_message
-    return mock_response
-
-
-def create_mock_response_with_malformed_tool():
-    """Create a mock response with a malformed tool_spec invocation"""
-    # Create a response object that simulates a malformed tool invocation
-    mock_response = MagicMock()
-    # Create a custom tool block that is missing required fields
-    malformed_tool = MagicMock()
-    malformed_tool.type = "tool_use"
-    malformed_tool.id = "tu_456"
-    # Intentionally missing name and input attributes
-
-    # Set up the final message
-    final_message = Message(
-        id="msg_456",
-        content=[malformed_tool],
-        model="claude-3-haiku-20240307",
-        role="assistant",
-        stop_reason="tool_use",
-        stop_sequence=None,
-        type="message",
-        usage=MagicMock(),
-    )
-    mock_response.get_final_message.return_value = final_message
-    return mock_response
-
-
-@patch("anthropic.resources.messages.Messages.stream")
-def test_unknown_tool_handled_gracefully(mock_stream):
-    """Test that the agent handles unknown tools gracefully"""
-    # Set up the mock stream to return a response with an unknown tool
-    mock_stream.return_value.__enter__.return_value = (
-        create_mock_response_with_unknown_tool()
-    )
-
-    # Create minimal context for testing
-    user_interface = MagicMock()
-    context = AgentContext.create(
-        model_spec={
-            "title": "claude-3-haiku-20240307",
-            "max_tokens": 1000,
-            "pricing": {"input": 0.25, "output": 1.25},
-        },
-        sandbox_mode=SandboxMode.ALLOW_ALL,
-        user_interface=user_interface,
-    )
-
-    # Add a message to the chat history
-    context.chat_history.append({"role": "user", "content": "Use a tool"})
-
-    # Run the agent
-    run(agent_context=context, single_response=True)
-
-    # Check that no exception was raised and the error was handled
-    # Verify the assistant reported an unknown function error
-    assert user_interface.handle_tool_result.called
-    tool_result_args = user_interface.handle_tool_result.call_args[0]
-    assert "unknown_tool" == tool_result_args[0]  # First arg is the tool name
-    assert "Unknown function" in tool_result_args[1]["content"]  # Error content
-
-
-@patch("anthropic.resources.messages.Messages.stream")
-def test_malformed_tool_spec_handled_gracefully(mock_stream):
-    """Test that the agent handles malformed tool specifications gracefully"""
-    # Set up the mock stream to return a response with a malformed tool
-    mock_stream.return_value.__enter__.return_value = (
-        create_mock_response_with_malformed_tool()
-    )
-
-    # Create minimal context for testing
-    user_interface = MagicMock()
-    context = AgentContext.create(
-        model_spec={
-            "title": "claude-3-haiku-20240307",
-            "max_tokens": 1000,
-            "pricing": {"input": 0.25, "output": 1.25},
-        },
-        sandbox_mode=SandboxMode.ALLOW_ALL,
-        user_interface=user_interface,
-    )
-
-    # Add a message to the chat history
-    context.chat_history.append({"role": "user", "content": "Use a malformed tool"})
-
-    # Run the agent - should not crash
-    run(agent_context=context, single_response=True)
-
-    # Verify the assistant handled the malformed tool gracefully
-    assert user_interface.handle_tool_result.called
-    # Tool name should default to "unknown_tool" when missing
-    assert "unknown_tool" in user_interface.handle_tool_result.call_args[0][0]
-    # Check that error message mentions invalid or missing attributes
-    result_content = user_interface.handle_tool_result.call_args[0][1]["content"]
-    assert "missing" in result_content.lower() or "invalid" in result_content.lower()
 
 
 def test_invoke_tool_with_empty_toolspec():
@@ -139,9 +73,19 @@ def test_invoke_tool_with_empty_toolspec():
     result = invoke_tool(context, {"type": "tool_use"})
     assert "Invalid tool specification" in result["content"]
 
-    # Test with MagicMock missing required attributes
-    mock_tool = MagicMock()
-    mock_tool.type = "tool_use"
-    # Intentionally missing name and input
+    # Create a mock that will raise AttributeError when name or input is accessed
+    class RestrictedMock:
+        type = "tool_use"
+        id = "mock_id"
+
+        def __getattribute__(self, name):
+            if name in ("name", "input"):
+                raise AttributeError(
+                    f"'{type(self).__name__}' object has no attribute '{name}'"
+                )
+            return super().__getattribute__(name)
+
+    # Test with our custom mock missing required attributes
+    mock_tool = RestrictedMock()
     result = invoke_tool(context, mock_tool)
     assert "Invalid tool specification" in result["content"]


### PR DESCRIPTION
## Description
This PR fixes issue [HDEV-40](https://plane.so/issue/HDEV-40) which caused hdev to crash when receiving unexpected tool specifications.

## Changes
- Added comprehensive error handling in `invoke_tool` (framework.py) to validate tool specs before accessing attributes
- Improved error handling in `invoke_agent_tool` (toolbox.py) to catch and properly report issues with tool specs
- Enhanced the agent run loop in agent.py to safely handle tool invocation errors
- Added test files to verify handling of malformed tool specs:
  - tests/test_unexpected_tool_spec.py - pytest-based tests
  - tests/test_tool_spec_simple.py - simple non-pytest tests

## Testing
The implementation includes test coverage for:
- Unknown tools being requested
- Tool specifications with missing attributes
- Invalid object types being passed as tool specs

All tests pass successfully, demonstrating that the code now handles these edge cases gracefully without crashing.