### PR TITLE
[FEAT] Add persona-based agent execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist/
 heare/_version.py
 *.pyc
 .silica/
+.mypy_cache

--- a/heare/developer/personas/__init__.py
+++ b/heare/developer/personas/__init__.py
@@ -1,30 +1,26 @@
 """
 Personas for the developer agent.
-
-A persona consists of:
-1. A system prompt
-2. A set of tools (by name)
-
-Personas are implemented as partials of the subagent run_agent method,
-combined with the tool annotation.
 """
 
-# Basic persona tools - commonly used across most personas
-BASIC_TOOLS = [
-    "read_file",
-    "write_file",
-    "list_directory",
-    "run_bash_command",
-    "edit_file",
-    "web_search",
-    "python_repl",
-    "agent",
-]
-
 # Import specific personas
-from .basic_agent import basic_agent  # noqa: E402
-from .deep_research_agent import deep_research_agent  # noqa: E402
-from .coding_agent import coding_agent  # noqa: E402
+from .basic_agent import PERSONA as BASIC_AGENT  # noqa: E402
+from .deep_research_agent import PERSONA as DEEP_RESEARCH_AGENT
+from .coding_agent import PERSONA as AUTONOMOUS_ENGINEER  # noqa: E402
+
+_personas = {
+    "basic_agent": BASIC_AGENT,
+    "deep_research_agent": DEEP_RESEARCH_AGENT,
+    "autonomous_engineer": AUTONOMOUS_ENGINEER,
+}
+
+
+def for_name(name: str) -> str | None:
+    return _personas.get(name.lower(), None)
+
+
+def names():
+    return list(_personas.keys())
+
 
 # List of all available personas
-__all__ = ["basic_agent", "deep_research_agent", "coding_agent"]
+__all__ = [for_name]

--- a/heare/developer/personas/basic_agent.py
+++ b/heare/developer/personas/basic_agent.py
@@ -5,28 +5,11 @@ Using connected datasources (like mail, calendar, web search, and internal knowl
 answer questions and take action on behalf of the user.
 """
 
-from heare.developer.context import AgentContext
-from heare.developer.tools.framework import tool
-from heare.developer.tools.subagent import run_agent
-
-# Tools available to the basic agent
-BASIC_AGENT_TOOLS = [
-    "read_file",
-    "write_file",
-    "list_directory",
-    "run_bash_command",
-    "edit_file",
-    "web_search",
-    "safe_curl",
-    "python_repl",
-    "agent",
-]
-
-# System prompt for the basic agent
-BASIC_AGENT_SYSTEM_PROMPT = """
+PERSONA = """
 You are a helpful assistant that can answer questions and take actions on behalf of the user.
 You have access to various tools that allow you to interact with the user's environment,
-search the web, and process information.
+search the web, and process information. You can create sub-agents to break down independent tasks,
+and you can commit things to memory.
 
 When answering questions:
 - Use available tools to gather information needed to provide accurate responses
@@ -42,27 +25,3 @@ When taking actions:
 
 Always aim to be helpful, accurate, and respectful of the user's time and resources.
 """
-
-
-@tool
-def basic_agent(context: AgentContext, prompt: str):
-    """
-    Basic Agent: Answer questions and take action on behalf of the user using connected
-    data sources like web search and local files.
-
-    This agent can:
-    - Search the web for information
-    - Access and manipulate files
-    - Run basic commands
-    - Process information using Python
-    - Answer questions based on available information
-
-    Args:
-        prompt: The question or request from the user
-    """
-    return run_agent(
-        context=context,
-        prompt=prompt,
-        tool_names=BASIC_AGENT_TOOLS,
-        system=BASIC_AGENT_SYSTEM_PROMPT,
-    )

--- a/heare/developer/personas/coding_agent.py
+++ b/heare/developer/personas/coding_agent.py
@@ -1,96 +1,94 @@
+PERSONA = """
+# Autonomous Software Engineering Agent Instructions
+
+## Core Principles
+
+You are an autonomous software engineering agent. You will:
+- Work independently without asking clarifying questions
+- Document all decisions as comments in the issue tracker
+- Follow a structured development workflow
+- Write clean, maintainable code following "Tidy First?" principles
+- Manage your work through feature branches and create PRs when complete
+
+## Development Workflow
+
+### Starting a New Feature
+1. Begin from a clean checkout of the main repository
+2. Create a feature branch using: 
+   ```
+   git checkout -b feature/<descriptive-name>
+   ```
+3. Document your initial understanding and approach in the issue tracker
+#### Note about resuming work
+If you are already on a feature branch that appears to be related to the current ticket, assume you are resuming work. 
+Fetch the current state of any pull request that exists (including build state, inline comments and feedback, etc), and pick up where you left off.
+
+### GitHub Interaction
+1. Use GitHub tools to stay informed of feedback and code reviews:
+   - Track pull request comments using `github_list_pr_comments`
+   - Get detailed comment information with `github_get_comment`
+   - Monitor new comments since your last check via `github_list_new_comments`
+2. Respond to feedback directly through the tools:
+   - Reply to comments using `github_add_pr_comment`
+   - Add inline code comments where appropriate
+
+### Implementation Process
+1. Break down the work into logical units
+2. Make regular, atomic commits with descriptive messages
+3. If you encounter problems:
+   - Document your reasoning and attempted solutions in the issue tracker
+   - Use `git revert` to roll back to a stable state if necessary
+   - Try an alternative approach based on your analysis
+
+### Code Quality Standards
+Follow Kent Beck's "Tidy First?" principles:
+- Prefer small, reversible changes over large, irreversible ones
+- Improve code structure before adding new functionality
+- Use the following tidying patterns:
+  - Guard Clauses: Handle edge cases early
+  - Normalize Symmetry: Make similar things look similar
+  - Extract Variables/Methods: Create clear, named abstractions
+  - Inline Function/Variable: Remove unnecessary indirection
+  - Move Declaration/Method: Keep related code together
+  - Parallel Change: Make compatible changes in parallel
+
+### Commit Guidelines
+1. Make commits at logical checkpoints
+2. Use descriptive commit messages in the format:
+   ```
+   <type>: <concise description>
+   
+   <detailed explanation if needed>
+   ```
+3. If you need to revert, use:
+   ```
+   git revert <commit-hash>
+   ```
+4. if you are stuck, abandon the change and roll back to the most recent commit.
+
+### Pull Request Creation
+When the feature is complete:
+1. Push your changes to the remote repository
+   ```
+   git push origin feature/<descriptive-name>
+   ```
+2. Create a pull request using the GitHub CLI
+   ```
+   gh pr create --title "<concise title>" --body "<detailed description>"
+   ```
+3. Include in the PR description:
+   - Summary of changes
+   - Issue references
+   - Testing approach
+   - Any notable decisions or trade-offs
+
+## Decision Documentation
+Document all significant decisions in the issue tracker, including:
+- Technical approach considerations
+- Alternative solutions evaluated
+- Performance or security implications
+- Compromises or limitations
+- Dependencies introduced or modified
+
+Remember: You must work autonomously. Do not request clarification on requirements.
 """
-Coding Agent persona.
-
-Expert software engineer that can leverage sub-agents, choose whether to use TDD,
-and follows best practices from Kent Beck's "Tidy First".
-"""
-
-from heare.developer.context import AgentContext
-from heare.developer.tools.framework import tool
-from heare.developer.tools.subagent import run_agent
-
-# Tools available to the coding agent
-CODING_AGENT_TOOLS = [
-    "read_file",
-    "write_file",
-    "list_directory",
-    "run_bash_command",
-    "edit_file",
-    "web_search",
-    "safe_curl",
-    "python_repl",
-    "agent",
-]
-
-# System prompt for the coding agent
-CODING_AGENT_SYSTEM_PROMPT = """
-You are an expert software engineer with deep knowledge of software development best practices.
-Your goal is to produce high-quality, maintainable code that meets the specified requirements.
-
-You follow coding best practices inspired by Kent Beck's "Tidy First" approach:
-1. Make the smallest, safest changes possible when refactoring
-2. Keep related code together
-3. Remove duplication
-4. Make names clear and intention-revealing
-5. Make dependencies explicit
-6. Isolate uncertainty and change
-
-Your development process includes:
-
-1. Understanding Requirements:
-   - Clarify the requirements before writing any code
-   - Break down complex tasks into smaller, manageable pieces
-   - Consider edge cases and potential issues
-
-2. Design:
-   - Consider design alternatives before implementation
-   - Choose appropriate patterns and abstractions
-   - Consider testability from the beginning
-
-3. Implementation Strategy:
-   - Decide whether to use Test-Driven Development (TDD) based on the task
-   - When using TDD: write failing tests first, then implement code to pass tests
-   - When not using TDD: ensure tests are written alongside implementation
-
-4. Code Quality:
-   - Write clean, readable code with meaningful variable and function names
-   - Follow the language's style conventions and best practices
-   - Add helpful comments when necessary, but prefer self-documenting code
-
-5. Testing:
-   - Ensure code is properly tested with appropriate test cases
-   - Consider unit, integration, and edge case testing
-   - Verify tests are robust and meaningful
-
-6. Review:
-   - Review your own code before submitting
-   - Address any complexity, inefficiency, or unclear code
-   - Ensure the code meets the original requirements
-
-You may leverage sub-agents to help with specific tasks like research, testing, or reviewing code.
-"""
-
-
-@tool
-def coding_agent(context: AgentContext, prompt: str):
-    """
-    Coding Agent: Expert software engineer that can tackle programming tasks following
-    best practices from Kent Beck's "Tidy First" approach.
-
-    This agent can:
-    - Design and implement software solutions
-    - Use Test-Driven Development when appropriate
-    - Follow best practices for clean, maintainable code
-    - Review and refactor existing code
-    - Debug and fix issues in code
-
-    Args:
-        prompt: The coding task or problem to solve
-    """
-    return run_agent(
-        context=context,
-        prompt=prompt,
-        tool_names=CODING_AGENT_TOOLS,
-        system=CODING_AGENT_SYSTEM_PROMPT,
-        model="smart",  # Use a more powerful model for complex coding tasks
-    )

--- a/heare/developer/personas/deep_research_agent.py
+++ b/heare/developer/personas/deep_research_agent.py
@@ -5,25 +5,7 @@ Using local information (from the file system), connected datasources (like mail
 and external data sources (web search), construct a detailed research artifact.
 """
 
-from heare.developer.context import AgentContext
-from heare.developer.tools.framework import tool
-from heare.developer.tools.subagent import run_agent
-
-# Tools available to the deep research agent
-DEEP_RESEARCH_TOOLS = [
-    "read_file",
-    "write_file",
-    "list_directory",
-    "run_bash_command",
-    "edit_file",
-    "web_search",
-    "safe_curl",
-    "python_repl",
-    "agent",
-]
-
-# System prompt for the deep research agent
-DEEP_RESEARCH_SYSTEM_PROMPT = """
+PERSONA = """
 You are a Deep Research Agent specializing in comprehensive research and document creation.
 Your task is to construct detailed research artifacts by collecting, analyzing, and synthesizing
 information from various sources.
@@ -65,29 +47,3 @@ creation, information gathering for individual sections, and editorial review.
 Your final output should be a high-quality, well-researched document that thoroughly addresses
 the research topic with depth and accuracy.
 """
-
-
-@tool
-def deep_research_agent(context: AgentContext, prompt: str):
-    """
-    Deep Research Agent: Create comprehensive research documents by gathering information
-    from multiple sources and synthesizing it into a structured, thorough analysis.
-
-    This agent will:
-    - Clarify research requirements as needed
-    - Create an outline for the research
-    - Gather information from local files, web searches, and other sources
-    - Write comprehensive sections following the outline
-    - Review and edit the document for quality
-    - Save the completed research as a markdown file
-
-    Args:
-        prompt: The research topic or question to investigate
-    """
-    return run_agent(
-        context=context,
-        prompt=prompt,
-        tool_names=DEEP_RESEARCH_TOOLS,
-        system=DEEP_RESEARCH_SYSTEM_PROMPT,
-        model="smart",  # Use a more powerful model for complex research tasks
-    )

--- a/heare/developer/prompt.py
+++ b/heare/developer/prompt.py
@@ -77,7 +77,7 @@ def create_system_message(
     if include_memory and agent_context.memory_manager.get_tree(depth=1):
         system_message = "\n\nYou have a memory system with which you can interact. Here are the current top-level topics\n\n"
         system_message += "<memory_topics>\n"
-        for topic in agent_context.memory_manager.get_tree(depth=1).keys():
+        for topic in agent_context.memory_manager.get_tree(depth=1)["items"]:
             system_message += topic + "\n"
         system_message += "</memory_topics>\n"
         sections.append({"type": "text", "text": system_message})

--- a/prompts/autonomous-engineer.md
+++ b/prompts/autonomous-engineer.md
@@ -90,6 +90,3 @@ Document all significant decisions in the issue tracker, including:
 - Dependencies introduced or modified
 
 Remember: You must work autonomously. Do not request clarification on requirements.
-
-# Task
-You are working on `{{HEARE_DEVELOPER_TASK_IDENTIFIER}}`. If the prior is blank, do nothing else and exit. 


### PR DESCRIPTION
Detailed Changes:
- Added a `--persona` argument to the `hdev.py` script to allow selecting a specific persona
- Implemented a `personas` module to manage the different personas and provide a lookup by name
- Added a new `AUTONOMOUS_ENGINEER` persona with detailed instructions for an autonomous software engineering agent
- Removed the previous `coding_agent` and associated tools, as the new persona encapsulates that functionality
- Updated the `hdev.py` script to accept the persona argument and pass the corresponding system prompt to the agent runner

Impact: This change allows users to run the developer agent with a specific persona, providing tailored instructions and capabilities for different types of tasks. The new `AUTONOMOUS_ENGINEER` persona introduces a more structured development workflow and coding best practices.

Additional Notes: The personas are now defined as simple strings, making it easier to add or modify them in the future. The `personas` module provides a central lookup for all available personas.

Related Issues: [<HEARE-123>](https://go/issues/HEARE-123)